### PR TITLE
Fix example in README

### DIFF
--- a/nnoir/README.md
+++ b/nnoir/README.md
@@ -11,14 +11,14 @@ pip install .
 ### create & save
 
 ```
-inputs  = [nnoir.Value(b'v0', dtype='float', shape=(10,10)),
-           nnoir.Value(b'v1', dtype='float', shape=(10,10))]
-outputs = [nnoir.Value(b'v2', dtype='float', shape=(10,10))]
+inputs  = [nnoir.Value(b'v0', dtype='<f4', shape=(10,10)),
+           nnoir.Value(b'v1', dtype='<f4', shape=(10,10))]
+outputs = [nnoir.Value(b'v2', dtype='<f4', shape=(10,10))]
 nodes = inputs + outputs
 input_names = [ x.name for x in inputs ]
 output_names = [ x.name for x in outputs ]
 functions = [nnoir.functions.Add(input_names, output_names)]
-result = nnoir.NNOIR(b'Add', b'add_test', 0.1, input_names, output_names, nodes, functions)
+result = nnoir.NNOIR(b'Add', b'add_test', '0.1', input_names, output_names, nodes, functions)
 result.dump('add.nnoir')
 ```
 


### PR DESCRIPTION
`nnoir.Value()` の引数の与え方が現バージョンのものと違っていたようなので修正