### PR TITLE
Fix module name from chainer.nnoir to nnoir_chainer

### DIFF
--- a/nnoir-chainer/nnoir_chainer/configuration.py
+++ b/nnoir-chainer/nnoir_chainer/configuration.py
@@ -12,7 +12,7 @@ def _patch__getattr__(self, name):
 
 def _patch__setattr__(self, name, value):
     if name == 'enable_backprop' and not value:
-        raise Exception('chainer.nnoir force enable_backprop')
+        raise Exception('nnoir_chainer force enable_backprop')
     setattr(self._local, name, value)
 
 


### PR DESCRIPTION
Fix error message which uses wrong module name.