### PR TITLE
Append `freeze_onnx` to assignment to dimension variables

### DIFF
--- a/nnoir-onnx/freeze_onnx
+++ b/nnoir-onnx/freeze_onnx
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from typing import Dict, Set
+
+import argparse
+import onnx
+
+
+def list_variables(model) -> Set[str]:
+    s = set()
+    for x in model.graph.input:
+        if x.type.HasField('tensor_type'):
+            for dim in x.type.tensor_type.shape.dim:
+                if dim.HasField('dim_param'):
+                    s.add(dim.dim_param)
+    return s
+
+
+def command_list(args) -> None:
+    model = onnx.load(args.input)
+    s = list_variables(model)
+    if len(s) != 0:
+        print(s)
+
+
+def command_freeze(args) -> None:
+    model = onnx.load(args.input)
+    s = list_variables(model)
+    diff = s.difference(set(args.fix_dimension.keys()))
+    if len(diff) != 0:
+        print("missing variables: " + str(diff))
+        return
+
+    for x in model.graph.input:
+        if x.type.HasField('tensor_type'):
+            for dim in x.type.tensor_type.shape.dim:
+                if dim.HasField('dim_param'):
+                    v = dim.dim_param
+                    dim.ClearField('dim_param')
+                    dim.dim_value = args.fix_dimension[v]
+    onnx.save(model, args.output)
+
+
+def parse_assign(s: str) -> Dict[str, int]:
+    d: Dict[str, int] = dict()
+    item: str
+    for item in s.split(','):
+        [v, n] = item.split('=')
+        d[v] = int(n)
+    return d
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='ONNX Freezer')
+    subparsers = parser.add_subparsers()
+
+    # freeze
+    parser_freeze = subparsers.add_parser('freeze', help='create freezed (statically sized) onnx')
+    parser_freeze.add_argument('-o', '--output', dest='output', type=str, required=True,
+                               metavar='NNOIR', help='output(NNOIR) file path')
+    parser_freeze.add_argument('--fix-dimension', type=parse_assign, dest='fix_dimension', required=True,
+                               help='assign statically unknown variables (like W=2,H=4. Cannot include spaces)')
+    parser_freeze.add_argument(dest='input', type=str,
+                               metavar='ONNX', help='input(ONNX) file path')
+    parser_freeze.set_defaults(handler=command_freeze)
+
+    # list
+    parser_list = subparsers.add_parser('list', help='list all statically unknown sized variables')
+    parser_list.add_argument(dest='input', type=str,
+                             metavar='ONNX', help='input(ONNX) file path')
+
+    parser_list.set_defaults(handler=command_list)
+
+    args = parser.parse_args()
+    if hasattr(args, 'handler'):
+        args.handler(args)
+    else:
+        parser.print_help()

--- a/nnoir-onnx/nnoir_onnx/onnx.py
+++ b/nnoir-onnx/nnoir_onnx/onnx.py
@@ -48,7 +48,7 @@ see https://github.com/onnx/onnx/blob/master/docs/IR.md#names-within-a-graph'''.
         variables = self._statically_unknown_variables()
         if variables != []:
             raise UnsupportedONNXOperation(
-                variables, "This onnx includes statically unknown sized variables. Try to remove them by assignment by `freeze_onnx`")
+                variables, "This ONNX model includes dimension variables. Try to remove them by assignment by `freeze_onnx`")
         self.constant_nodes = self._eval_nodes(self._list_constant_nodes())
 
     def _reconstruct_value_info(self):

--- a/nnoir-onnx/setup.py
+++ b/nnoir-onnx/setup.py
@@ -25,5 +25,5 @@ setup(
     keywords='nnoir machine learning onnx',
     packages=find_packages(),
     install_requires=['numpy', 'msgpack-python', 'onnx', 'onnxruntime', 'nnoir'],
-    scripts=['onnx2nnoir']
+    scripts=['onnx2nnoir', "freeze_onnx"]
 )


### PR DESCRIPTION
This PR includes the follows:

- `onnx2nnoior` will aborts if [dimension variables](https://github.com/onnx/onnx/blob/master/docs/IR.md) are included in ONNX files
- append `freeze_onnx` script to assign the actual integers to dimension variables 

## usage

```
$ freeze_onnx freeze -o freezed_model.onnx --fix-dimension H=1,W=2 Model.onnx 
```

```
$ freeze_onnx list Model.onnx
{'H', 'W'}
```

