### PR TITLE
nnoir-onnx: rename initializer name.

### DIFF
--- a/nnoir-onnx/nnoir_onnx/onnx.py
+++ b/nnoir-onnx/nnoir_onnx/onnx.py
@@ -49,7 +49,7 @@ class ONNX:
         self.model = infer_shapes(onnx.load(path))
         onnx.checker.check_model(self.model)
         # All names MUST adhere to C identifier syntax rules.
-        if not re.match(r'[_A-Za-z][_0-9A-Za-z]*', self.model.graph.name):
+        if not re.match(r'^[_A-Za-z][_0-9A-Za-z]*$', self.model.graph.name):
             raise InvalidONNXData('''graph name "{}" is not C identifier.
 see https://github.com/onnx/onnx/blob/master/docs/IR.md#names-within-a-graph'''.format(self.model.graph.name))
         self._rename_to_c_ident()
@@ -70,11 +70,11 @@ see https://github.com/onnx/onnx/blob/master/docs/IR.md#names-within-a-graph'''.
             rename_step = 0
             rename_prefix = 'v_from_initializer'
             rename_content = initializer.name
-            if re.match(r'[_A-Za-z][_0-9A-Za-z]*', rename_content):
+            if re.match(r'^[_A-Za-z][_0-9A-Za-z]*$', rename_content):
+                rename_prefix += '_plain'
+            else:
                 rename_content = ''.join(map(lambda c: 'x{:02x}'.format(ord(c)), rename_content))
                 rename_prefix += '_encoded'
-            else:
-                rename_prefix += '_plain'
             rename_candidate = "{}_{}_{}".format(rename_prefix, rename_step, rename_content)
             while True:
                 if rename_candidate not in value_names:

--- a/nnoir-onnx/nnoir_onnx/onnx.py
+++ b/nnoir-onnx/nnoir_onnx/onnx.py
@@ -44,6 +44,7 @@ def op_for_node(node):
 
 
 class ONNX:
+
     def __init__(self, path):
         self.model = infer_shapes(onnx.load(path))
         onnx.checker.check_model(self.model)
@@ -51,6 +52,7 @@ class ONNX:
         if not re.match(r'[_A-Za-z][_0-9A-Za-z]*', self.model.graph.name):
             raise InvalidONNXData('''graph name "{}" is not C identifier.
 see https://github.com/onnx/onnx/blob/master/docs/IR.md#names-within-a-graph'''.format(self.model.graph.name))
+        self._rename_to_c_ident()
         self.sess = onnxruntime.InferenceSession(path)
         constant_nodes = self._list_constant_nodes()
         self.nodes = self._try_run()
@@ -60,11 +62,42 @@ see https://github.com/onnx/onnx/blob/master/docs/IR.md#names-within-a-graph'''.
                 variables, "This ONNX model includes dimension variables. Try to remove them by assignment by `freeze_onnx`")
         self.constant_nodes = self._eval_nodes(constant_nodes)
 
+    def _rename_to_c_ident(self):
+        m = infer_shapes(copy.deepcopy(self.model))
+        value_names = [i.name for i in m.graph.input] + [v.name for v in m.graph.value_info]
+        # Initializer id is not restricted C identifier syntax rules.
+        for initializer in self.model.graph.initializer:
+            rename_step = 0
+            rename_prefix = 'v_from_initializer'
+            rename_content = initializer.name
+            if re.match(r'[_A-Za-z][_0-9A-Za-z]*', rename_content):
+                rename_content = ''.join(map(lambda c: 'x{:02x}'.format(ord(c)), rename_content))
+                rename_prefix += '_encoded'
+            else:
+                rename_prefix += '_plain'
+            rename_candidate = "{}_{}_{}".format(rename_prefix, rename_step, rename_content)
+            while True:
+                if rename_candidate not in value_names:
+                    value_names.append(rename_candidate)
+                    break
+                rename_step += 1
+                rename_candidate = "{}_{}_{}".format(rename_prefix, rename_step, rename_content)
+            # rename initializer.name -> rename_candidate
+            for n in self.model.graph.node:
+                for i in range(len(n.input)):
+                    if n.input[i] == initializer.name:
+                        n.input[i] = rename_candidate
+            initializer.name = rename_candidate
+
     def _try_run(self):
         m = infer_shapes(copy.deepcopy(self.model))
         values = [v.name for v in m.graph.value_info]
         m.graph.output.extend(m.graph.input)
         m.graph.output.extend(m.graph.value_info)
+
+        def tensor_to_value_info(t):
+            return onnx.helper.make_tensor_value_info(t.name, t.data_type, None)
+        m.graph.output.extend(list(map(tensor_to_value_info, m.graph.initializer)))
         inits = [v.name for v in m.graph.initializer]
         input_values = [v for v in m.graph.input if v.name not in inits]
         outputs = [

--- a/nnoir/nnoir/nnoir.py
+++ b/nnoir/nnoir/nnoir.py
@@ -11,7 +11,7 @@ class InvalidNNOIRData(Exception):
 class NNOIR():
 
     def __init__(self, name, generator_name, generator_version, inputs, outputs, values, functions):
-        cident = re.compile(rb'[_A-Za-z][_0-9A-Za-z]*')
+        cident = re.compile(rb'^[_A-Za-z][_0-9A-Za-z]*$')
         c_keywords = [
             'auto', 'break', 'case',
             'char', 'const', 'continue',


### PR DESCRIPTION
Initializer name is not restricted to C identifier syntax rule. (Why?)
see https://github.com/onnx/onnx/blob/master/docs/IR.md#names-within-a-graph