### PR TITLE
Fix onnx version (temporary)

### DIFF
--- a/nnoir-onnx/setup.py
+++ b/nnoir-onnx/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         'numpy',
         'msgpack-python',
-        'onnx',
+        'onnx==1.6.0',
         'onnxruntime>=1.2.0',
         'nnoir',
         'protobuf>=3.8'


### PR DESCRIPTION
Fix onnx version.

This is due to incompatible between `onnx` and `onnxruntime`.
Currently, `onnxruntime` does not support `ir_version = 7` and `opset version = 12` (provided since `onnx 1.7.0`).
This makes all tests of `nnoir-onnx` will fail.

