### PR TITLE
nnoir-onnx: remove version restriction

### DIFF
--- a/nnoir-onnx/setup.py
+++ b/nnoir-onnx/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         'numpy',
         'msgpack-python',
-        'onnx==1.6.0',
+        'onnx',
         'onnxruntime>=1.2.0',
         'nnoir',
         'protobuf>=3.8'


### PR DESCRIPTION
Thanks to the update of `onnxruntime`, opset 12 can be tested.
Then, we can remove version restriction.

https://github.com/Microsoft/onnxruntime/releases/tag/v1.3.0