### PR TITLE
Use pytest && split tests into `test` and `test-chainer-component`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            pip3 install nose
-            pip3 install autopep8
+            pip3 install pytest autopep8
       - run:
           name: Check nnoir library code format
           working_directory: nnoir
@@ -30,7 +29,7 @@ jobs:
           name: Test nnoir library
           working_directory: nnoir
           command: |
-            nosetests -v test
+            pytest -v
       - run:
           name: Check nnoir-onnx library code format
           working_directory: nnoir-onnx
@@ -42,9 +41,28 @@ jobs:
           command: |
             python3 setup.py install
       - run:
+          name: Test nnoir-onnx
+          working_directory: nnoir-onnx
+          command: |
+            pytest -v
+      - run:
           name: Test nnoir-onnx example
           command: |
             make -C nnoir-onnx/example/mobilenetv2
+
+  test-chainer-component:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            pip3 install pytest autopep8
+      - run:
+          name: Install nnoir library
+          working_directory: nnoir
+          command: |
+            python3 setup.py install
       - run:
           name: Check nnoir-chainer library code format
           working_directory: nnoir-chainer
@@ -60,16 +78,11 @@ jobs:
           name: Test nnoir-chainer library
           working_directory: nnoir-chainer
           command: |
-            nosetests -v test
+            pytest -v
       - run:
           name: Test nnoir-chainer example
           command: |
             make -C nnoir-chainer/example/mnist
-      - run:
-          name: Test nnoir-onnx
-          working_directory: nnoir-onnx
-          command: |
-            nosetests -v test
 
 
 workflows:
@@ -77,3 +90,4 @@ workflows:
   test:
     jobs:
       - test
+      - test-chainer-component

--- a/nnoir-onnx/test/test_average_pooling_2d.py
+++ b/nnoir-onnx/test/test_average_pooling_2d.py
@@ -1,10 +1,9 @@
+from util import Base
+from onnx import TensorProto
+from onnx.helper import make_node, make_graph, make_model, make_tensor_value_info
+import onnx
 import numpy as np
 
-import onnx
-from onnx.helper import make_node, make_graph, make_model, make_tensor_value_info
-from onnx import TensorProto
-
-from util import Base
 
 info = make_tensor_value_info
 

--- a/nnoir-onnx/test/test_concat.py
+++ b/nnoir-onnx/test/test_concat.py
@@ -5,7 +5,7 @@ from onnx.numpy_helper import from_array
 import onnx
 import numpy as np
 
-from nose.tools import raises
+import pytest
 
 info = make_tensor_value_info
 
@@ -47,7 +47,7 @@ def test_concat_01():
     ConcatTester({"v0": v0, "v1": v1, "v2": v2}, outputs).run()
 
 
-@raises(Exception)
+@pytest.mark.xfail()
 def test_concat_02():
     '''
     Test to get value from initializers directly.

--- a/nnoir-onnx/test/test_dropout.py
+++ b/nnoir-onnx/test/test_dropout.py
@@ -1,5 +1,4 @@
-from nose.tools import raises
-
+import pytest
 import numpy as np
 
 import onnx
@@ -41,7 +40,7 @@ def test_dropout_00():
     DropoutTester({"v0": v0, "v1": v1}, outputs).run()
 
 
-@raises(Exception)
+@pytest.mark.xfail()
 def test_dropout_01():
     class DropoutTester(Base):
         '''

--- a/nnoir-onnx/test/test_elu.py
+++ b/nnoir-onnx/test/test_elu.py
@@ -5,8 +5,6 @@ from onnx.numpy_helper import from_array
 import onnx
 import numpy as np
 
-from nose.tools import raises
-
 info = make_tensor_value_info
 
 

--- a/nnoir-onnx/test/test_flatten.py
+++ b/nnoir-onnx/test/test_flatten.py
@@ -5,8 +5,6 @@ from onnx.numpy_helper import from_array
 import onnx
 import numpy as np
 
-from nose.tools import raises
-
 info = make_tensor_value_info
 
 

--- a/nnoir-onnx/test/test_gemm.py
+++ b/nnoir-onnx/test/test_gemm.py
@@ -5,7 +5,7 @@ from onnx.numpy_helper import from_array
 import onnx
 import numpy as np
 
-from nose.tools import raises
+import pytest
 
 info = make_tensor_value_info
 
@@ -43,7 +43,7 @@ def test_gemm_00():
     GemmTester(inputs, outputs).run()
 
 
-@raises(Exception)
+@pytest.mark.xfail()
 def test_gemm_01():
     '''
     unidirectional broadcasting is not supported

--- a/nnoir-onnx/test/test_lrn.py
+++ b/nnoir-onnx/test/test_lrn.py
@@ -5,8 +5,6 @@ from onnx.numpy_helper import from_array
 import onnx
 import numpy as np
 
-from nose.tools import raises
-
 info = make_tensor_value_info
 
 

--- a/nnoir-onnx/test/test_matmul.py
+++ b/nnoir-onnx/test/test_matmul.py
@@ -5,7 +5,7 @@ from onnx.numpy_helper import from_array
 import onnx
 import numpy as np
 
-from nose.tools import raises
+import pytest
 
 info = make_tensor_value_info
 
@@ -37,7 +37,7 @@ def test_matmul_00():
     MatMulTester({"x": x}, outputs).run()
 
 
-@raises(Exception)
+@pytest.mark.xfail()
 def test_matmul_01():
     '''
     opset version >= 9
@@ -64,6 +64,7 @@ def test_matmul_01():
     outputs = ["y"]
     MatMulTester({"x": x}, outputs).run()
 
+
 def test_matmul_02():
     '''
     opset version >= 9
@@ -88,6 +89,7 @@ def test_matmul_02():
 
     outputs = ["z"]
     MatMulTester({"x": x, "y": y}, outputs).run()
+
 
 def test_matmul_03():
     '''
@@ -114,6 +116,7 @@ def test_matmul_03():
     outputs = ["z"]
     MatMulTester({"x": x, "y": y}, outputs).run()
 
+
 def test_matmul_04():
     '''
     opset version >= 9
@@ -139,6 +142,7 @@ def test_matmul_04():
     outputs = ["z"]
     MatMulTester({"x": x, "y": y}, outputs).run()
 
+
 def test_matmul_05():
     '''
     opset version >= 9
@@ -163,4 +167,3 @@ def test_matmul_05():
 
     outputs = ["z"]
     MatMulTester({"x": x, "y": y}, outputs).run()
-

--- a/nnoir-onnx/test/test_max_pooling.py
+++ b/nnoir-onnx/test/test_max_pooling.py
@@ -7,7 +7,8 @@ from onnx import TensorProto
 from nnoir_onnx.operators.utils import UnsupportedONNXOperation
 
 from util import Base
-from nose.tools import raises
+
+import pytest
 
 info = make_tensor_value_info
 
@@ -29,7 +30,7 @@ def test_max_pool_00():
     MaxPoolTester({"v0": v0}, outputs).run()
 
 
-@raises(UnsupportedONNXOperation)
+@pytest.mark.xfail()
 def test_max_pool_01():
     '''
     opset version >= 10
@@ -52,7 +53,7 @@ def test_max_pool_01():
     MaxPoolTester({"v0": v0}, outputs).run()
 
 
-@raises(UnsupportedONNXOperation)
+@pytest.mark.xfail(raises=UnsupportedONNXOperation)
 def test_max_pool_02():
     '''
     opset version >= 11

--- a/nnoir-onnx/test/test_mul.py
+++ b/nnoir-onnx/test/test_mul.py
@@ -6,7 +6,6 @@ import onnx
 import numpy as np
 
 from nnoir_onnx.operators.utils import UnsupportedONNXOperation
-from nose.tools import raises
 
 info = make_tensor_value_info
 


### PR DESCRIPTION
- Replace nosetests with pytest
  - Currently, printing test names are difficult to see in `nnoir-onnx`. (nosetests use comments like "opset version > ...")
     pytest give us finer controls.
   - Development of pytest is more active.
- Split  all test into usual tests and chainer related component test for speed-up testing.