### PR TITLE
avoid Docker Hub rate limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
 version: 2
+
 references:
   defaults: &defaults
     docker:
       - image: python:3.7-buster
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     environment:
       TZ: "/usr/share/zoneinfo/Asia/Tokyo"
 
@@ -89,5 +93,9 @@ workflows:
   version: 2
   test:
     jobs:
-      - test
-      - test-chainer-component
+      - test:
+          context:
+            - docker-hub-creds
+      - test-chainer-component:
+          context:
+            - docker-hub-creds


### PR DESCRIPTION
Add auth information for pulling docker executor images to avoid Docker Hub's anonymous pull limitation.

cf. https://circleci.com/docs/2.0/private-images/

```
Hi there,

On November 1st, Docker Hub will begin limiting anonymous image pulls. We want to make sure you know how you might be impacted and what you can do to avoid interruptions to your workflow.

Adding Docker authentication to your pipeline config is the easiest way to avoid any service disruptions. If you use the Docker executor or pull Docker images when using the machine executor on CircleCI, we encourage you to authenticate. Because the anonymous API rate limits are based on IP addresses, they will impact CircleCI cloud customers. Authenticated users get higher per-user rate limits, regardless of IP.

We are currently working on a partnership with Docker to minimize the impact of this change for our users and will share more details as we get them.

For more information or to leave a question for us, please head over to Discuss or contact support.

Thanks and happy building,

- The CircleCI team
```