### PR TITLE
Check shape in onnx2nnoir

### DIFF
--- a/nnoir-onnx/freeze_onnx
+++ b/nnoir-onnx/freeze_onnx
@@ -8,14 +8,14 @@ from nnoir_onnx import utils
 
 def command_list(args) -> None:
     model = onnx.load(args.input)
-    s = utils.list_statically_unknown_sized_variables(model)
+    s = utils.list_dimension_variables(model)
     if len(s) != 0:
         print(s)
 
 
 def command_freeze(args) -> None:
     model = onnx.load(args.input)
-    s = utils.list_statically_unknown_sized_variables(model)
+    s = utils.list_dimension_variables(model)
     diff = s.difference(set(args.fix_dimension.keys()))
     if len(diff) != 0:
         print("missing variables: " + str(diff))

--- a/nnoir-onnx/freeze_onnx
+++ b/nnoir-onnx/freeze_onnx
@@ -3,28 +3,19 @@ from typing import Dict, Set
 
 import argparse
 import onnx
-
-
-def list_variables(model) -> Set[str]:
-    s = set()
-    for x in model.graph.input:
-        if x.type.HasField('tensor_type'):
-            for dim in x.type.tensor_type.shape.dim:
-                if dim.HasField('dim_param'):
-                    s.add(dim.dim_param)
-    return s
+from nnoir_onnx import utils
 
 
 def command_list(args) -> None:
     model = onnx.load(args.input)
-    s = list_variables(model)
+    s = utils.list_statically_unknown_sized_variables(model)
     if len(s) != 0:
         print(s)
 
 
 def command_freeze(args) -> None:
     model = onnx.load(args.input)
-    s = list_variables(model)
+    s = utils.list_statically_unknown_sized_variables(model)
     diff = s.difference(set(args.fix_dimension.keys()))
     if len(diff) != 0:
         print("missing variables: " + str(diff))

--- a/nnoir-onnx/nnoir_onnx/__init__.py
+++ b/nnoir-onnx/nnoir_onnx/__init__.py
@@ -1,4 +1,5 @@
 from .onnx import ONNX
+from .utils import *
 from nnoir_onnx import _version
 
 __version__ = _version.__version__

--- a/nnoir-onnx/nnoir_onnx/utils.py
+++ b/nnoir-onnx/nnoir_onnx/utils.py
@@ -1,0 +1,11 @@
+from typing import Dict, Set
+
+def list_statically_unknown_sized_variables(model) -> Set[str]:
+    s = set()
+    for x in model.graph.input:
+        if x.type.HasField('tensor_type'):
+            for dim in x.type.tensor_type.shape.dim:
+                if dim.HasField('dim_param'):
+                    s.add(dim.dim_param)
+    return s
+

--- a/nnoir-onnx/nnoir_onnx/utils.py
+++ b/nnoir-onnx/nnoir_onnx/utils.py
@@ -1,5 +1,6 @@
 from typing import Dict, Set
 
+
 def list_dimension_variables(model) -> Set[str]:
     s = set()
     for x in model.graph.input:
@@ -8,4 +9,3 @@ def list_dimension_variables(model) -> Set[str]:
                 if dim.HasField('dim_param'):
                     s.add(dim.dim_param)
     return s
-

--- a/nnoir-onnx/nnoir_onnx/utils.py
+++ b/nnoir-onnx/nnoir_onnx/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set
+from typing import Set
 
 
 def list_dimension_variables(model) -> Set[str]:

--- a/nnoir-onnx/nnoir_onnx/utils.py
+++ b/nnoir-onnx/nnoir_onnx/utils.py
@@ -1,6 +1,6 @@
 from typing import Dict, Set
 
-def list_statically_unknown_sized_variables(model) -> Set[str]:
+def list_dimension_variables(model) -> Set[str]:
     s = set()
     for x in model.graph.input:
         if x.type.HasField('tensor_type'):

--- a/nnoir-onnx/onnx2nnoir
+++ b/nnoir-onnx/onnx2nnoir
@@ -6,7 +6,7 @@ from nnoir_onnx import ONNX, utils
 
 def check_graph(input_path):
     model = onnx.load(input_path)
-    vs = utils.list_statically_unknown_sized_variables(model)
+    vs = utils.list_dimension_variables(model)
     if len(vs) != 0:
         sys.exit(f"""Error: This ONNX model includes dimension variables.
 {vs}

--- a/nnoir-onnx/onnx2nnoir
+++ b/nnoir-onnx/onnx2nnoir
@@ -1,6 +1,17 @@
 #!/usr/bin/env python3
 import argparse
-from nnoir_onnx import ONNX
+import onnx
+import sys
+from nnoir_onnx import ONNX, utils
+
+def check_graph(input_path):
+    model = onnx.load(input_path)
+    vs = utils.list_statically_unknown_sized_variables(model)
+    if len(vs) != 0:
+        sys.exit(f"""Error: This ONNX model includes dimension variables.
+{vs}
+Set the values with `freeze_onnx freeze`.
+$ freeze_onnx freeze --help""")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ONNX to NNOIR Converter')
@@ -9,4 +20,5 @@ if __name__ == '__main__':
     parser.add_argument(dest='input', type=str,
                         metavar='ONNX', help='input(ONNX) file path')
     args = parser.parse_args()
+    check_graph(args.input)
     ONNX(args.input).to_NNOIR().dump(args.output)

--- a/nnoir-onnx/onnx2nnoir
+++ b/nnoir-onnx/onnx2nnoir
@@ -4,6 +4,7 @@ import onnx
 import sys
 from nnoir_onnx import ONNX, utils
 
+
 def check_graph(input_path):
     model = onnx.load(input_path)
     vs = utils.list_dimension_variables(model)
@@ -12,6 +13,7 @@ def check_graph(input_path):
 {vs}
 Set the values with `freeze_onnx freeze`.
 $ freeze_onnx freeze --help""")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ONNX to NNOIR Converter')


### PR DESCRIPTION
Deal with #72.

The following error is displayed.

```
% onnx2nnoir -o example/super_resolution/super_resolution.nnoir example/super_resolution/super_resolution/super_resolution.onnx
Error: This ONNX model includes dimension variables.
{'batch_size'}
Set the values with `freeze_onnx freeze`.
$ freeze_onnx freeze --help
```