### PR TITLE
Add --graph_name option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
           name: Test nnoir-onnx example
           command: |
             make -C nnoir-onnx/example/mobilenetv2
+            make -C nnoir-onnx/example/super_resolution
 
   test-chainer-component:
     <<: *defaults

--- a/nnoir-onnx/example/.gitignore
+++ b/nnoir-onnx/example/.gitignore
@@ -1,0 +1,2 @@
+*.onnx
+*.nnoir

--- a/nnoir-onnx/example/super_resolution/Makefile
+++ b/nnoir-onnx/example/super_resolution/Makefile
@@ -1,0 +1,10 @@
+all: super_resolution.nnoir
+
+super_resolution.onnx:
+	wget -O $@ https://github.com/onnx/models/raw/master/vision/super_resolution/sub_pixel_cnn_2016/model/super-resolution-10.onnx
+
+super_resolution.fixed.onnx: super_resolution.onnx
+	freeze_onnx freeze -o $@ --fix-dimension batch_size=1 $<
+
+super_resolution.nnoir: super_resolution.fixed.onnx
+	onnx2nnoir -o $@ --graph_name torch_jit_export $<

--- a/nnoir-onnx/nnoir_onnx/onnx.py
+++ b/nnoir-onnx/nnoir_onnx/onnx.py
@@ -37,13 +37,16 @@ def value_info_to_zero_narray(vi):
 
 class ONNX:
 
-    def __init__(self, path):
+    def __init__(self, path, graph_name=None):
         self.model = onnx.load(path)
+        if graph_name is not None:
+            self.model.graph.name = graph_name
         onnx.checker.check_model(self.model)
         # All names MUST adhere to C identifier syntax rules.
         if not re.match(r'^[_A-Za-z][_0-9A-Za-z]*$', self.model.graph.name):
             raise InvalidONNXData(f'''graph name "{self.model.graph.name}" is not C identifier.
-see https://github.com/onnx/onnx/blob/master/docs/IR.md#names-within-a-graph''')
+see https://github.com/onnx/onnx/blob/master/docs/IR.md#names-within-a-graph.
+You can override the graph name with the `--graph_name` option.''')
         variables = list_dimension_variables(self.model)
         if len(variables) != 0:
             raise UnknownSizedVariable(f'''This ONNX model includes dimension variables.

--- a/nnoir-onnx/onnx2nnoir
+++ b/nnoir-onnx/onnx2nnoir
@@ -9,10 +9,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ONNX to NNOIR Converter')
     parser.add_argument('-o', '--output', dest='output', type=str, required=True,
                         metavar='NNOIR', help='output(NNOIR) file path')
+    parser.add_argument('--graph_name', dest='graph_name', type=str, required=False,
+                        metavar='C_IDENT', help='new graph name (it must be a C identifer.)')
     parser.add_argument(dest='input', type=str,
                         metavar='ONNX', help='input(ONNX) file path')
     args = parser.parse_args()
     try:
-        ONNX(args.input).to_NNOIR().dump(args.output)
+        ONNX(args.input, args.graph_name).to_NNOIR().dump(args.output)
     except Exception as e:
         sys.exit(f"Error: {e}")


### PR DESCRIPTION
```
% ./onnx2nnoir -o example/super_resolution/super_resolution.nnoir tmp/super_resolution_fixed.onnx
Error: graph name "torch-jit-export" is not C identifier.
see https://github.com/onnx/onnx/blob/master/docs/IR.md#names-within-a-graph.
You can override the graph name with the `--graph_name` option.
% ./onnx2nnoir -o example/super_resolution/super_resolution.nnoir --graph_name torch_jit_export tmp/super_resolution_fixed.onnx
2020-11-06 11:30:49.197308735 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv1.bias appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 11:30:49.199261490 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv1.weight appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 11:30:49.199566555 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv2.bias appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 11:30:49.199706237 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv2.weight appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 11:30:49.199836979 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv3.bias appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 11:30:49.200015493 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv3.weight appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 11:30:49.200156572 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv4.bias appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 11:30:49.200286476 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv4.weight appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
```