### PR TITLE
Add --fix_dimension option

### DIFF
--- a/nnoir-onnx/example/super_resolution/Makefile
+++ b/nnoir-onnx/example/super_resolution/Makefile
@@ -3,8 +3,5 @@ all: super_resolution.nnoir
 super_resolution.onnx:
 	wget -O $@ https://github.com/onnx/models/raw/master/vision/super_resolution/sub_pixel_cnn_2016/model/super-resolution-10.onnx
 
-super_resolution.fixed.onnx: super_resolution.onnx
-	freeze_onnx freeze -o $@ --fix-dimension batch_size=1 $<
-
-super_resolution.nnoir: super_resolution.fixed.onnx
-	onnx2nnoir -o $@ --graph_name torch_jit_export $<
+super_resolution.nnoir: super_resolution.onnx
+	onnx2nnoir -o $@ --graph_name torch_jit_export --fix_dimension batch_size=1 $<

--- a/nnoir-onnx/freeze_onnx
+++ b/nnoir-onnx/freeze_onnx
@@ -16,7 +16,7 @@ def command_list(args) -> None:
 def command_freeze(args) -> None:
     model = onnx.load(args.input)
     fixed_model = utils.freeze_dimension_variables(model, args.fix_dimension)
-    onnx.save(model, args.output)
+    onnx.save(fixed_model, args.output)
 
 
 if __name__ == '__main__':

--- a/nnoir-onnx/freeze_onnx
+++ b/nnoir-onnx/freeze_onnx
@@ -15,29 +15,8 @@ def command_list(args) -> None:
 
 def command_freeze(args) -> None:
     model = onnx.load(args.input)
-    s = utils.list_dimension_variables(model)
-    diff = s.difference(set(args.fix_dimension.keys()))
-    if len(diff) != 0:
-        print("missing variables: " + str(diff))
-        return
-
-    for x in model.graph.input:
-        if x.type.HasField('tensor_type'):
-            for dim in x.type.tensor_type.shape.dim:
-                if dim.HasField('dim_param'):
-                    v = dim.dim_param
-                    dim.ClearField('dim_param')
-                    dim.dim_value = args.fix_dimension[v]
+    fixed_model = utils.freeze_dimension_variables(model, args.fix_dimension)
     onnx.save(model, args.output)
-
-
-def parse_assign(s: str) -> Dict[str, int]:
-    d: Dict[str, int] = dict()
-    item: str
-    for item in s.split(','):
-        [v, n] = item.split('=')
-        d[v] = int(n)
-    return d
 
 
 if __name__ == '__main__':
@@ -48,7 +27,7 @@ if __name__ == '__main__':
     parser_freeze = subparsers.add_parser('freeze', help='create freezed (statically sized) onnx')
     parser_freeze.add_argument('-o', '--output', dest='output', type=str, required=True,
                                metavar='ONNX', help='output(ONNX) file path')
-    parser_freeze.add_argument('--fix-dimension', type=parse_assign, dest='fix_dimension', required=True,
+    parser_freeze.add_argument('--fix-dimension', type=utils.parse_assign, dest='fix_dimension', required=True,
                                help='assign statically unknown variables (like W=2,H=4. Cannot include spaces)')
     parser_freeze.add_argument(dest='input', type=str,
                                metavar='ONNX', help='input(ONNX) file path')

--- a/nnoir-onnx/freeze_onnx
+++ b/nnoir-onnx/freeze_onnx
@@ -20,6 +20,7 @@ def command_freeze(args) -> None:
 
 
 if __name__ == '__main__':
+    print('Warning: freeze_onnx is deprecated. Instead use `onnx2nnoir --fix_dimension`.')
     parser = argparse.ArgumentParser(description='ONNX Freezer')
     subparsers = parser.add_subparsers()
 

--- a/nnoir-onnx/nnoir_onnx/utils.py
+++ b/nnoir-onnx/nnoir_onnx/utils.py
@@ -1,4 +1,5 @@
-from typing import Set
+from typing import Dict, Set
+from .operators.utils import UnknownSizedVariable
 
 
 def list_dimension_variables(model) -> Set[str]:
@@ -9,3 +10,29 @@ def list_dimension_variables(model) -> Set[str]:
                 if dim.HasField('dim_param'):
                     s.add(dim.dim_param)
     return s
+
+
+def freeze_dimension_variables(model, fix_dimension):
+    s = list_dimension_variables(model)
+    diff = s.difference(set(fix_dimension.keys()))
+    if len(diff) != 0:
+        raise UnknownSizedVariable("missing variables: " + str(diff))
+
+    for x in model.graph.input:
+        if x.type.HasField('tensor_type'):
+            for dim in x.type.tensor_type.shape.dim:
+                if dim.HasField('dim_param'):
+                    v = dim.dim_param
+                    dim.ClearField('dim_param')
+                    dim.dim_value = fix_dimension[v]
+
+    return model
+
+
+def parse_assign(s: str) -> Dict[str, int]:
+    d: Dict[str, int] = dict()
+    item: str
+    for item in s.split(','):
+        [v, n] = item.split('=')
+        d[v] = int(n)
+    return d

--- a/nnoir-onnx/onnx2nnoir
+++ b/nnoir-onnx/onnx2nnoir
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     parser.add_argument('--graph_name', dest='graph_name', type=str, required=False,
                         metavar='C_IDENT', help='new graph name (it must be a C identifer.)')
     parser.add_argument('--fix_dimension', type=utils.parse_assign, dest='fix_dimension', required=False,
-                        help='assign statically unknown variables (like W=2,H=4. Cannot include spaces)')
+                        help='assign dimension variables (like W=2,H=4. Cannot include spaces)')
     parser.add_argument(dest='input', type=str,
                         metavar='ONNX', help='input(ONNX) file path')
     args = parser.parse_args()

--- a/nnoir-onnx/onnx2nnoir
+++ b/nnoir-onnx/onnx2nnoir
@@ -2,7 +2,7 @@
 import argparse
 import onnx
 import sys
-from nnoir_onnx import ONNX
+from nnoir_onnx import ONNX, utils
 
 
 if __name__ == '__main__':
@@ -11,10 +11,12 @@ if __name__ == '__main__':
                         metavar='NNOIR', help='output(NNOIR) file path')
     parser.add_argument('--graph_name', dest='graph_name', type=str, required=False,
                         metavar='C_IDENT', help='new graph name (it must be a C identifer.)')
+    parser.add_argument('--fix_dimension', type=utils.parse_assign, dest='fix_dimension', required=False,
+                        help='assign statically unknown variables (like W=2,H=4. Cannot include spaces)')
     parser.add_argument(dest='input', type=str,
                         metavar='ONNX', help='input(ONNX) file path')
     args = parser.parse_args()
     try:
-        ONNX(args.input, args.graph_name).to_NNOIR().dump(args.output)
+        ONNX(args.input, args.graph_name, args.fix_dimension).to_NNOIR().dump(args.output)
     except Exception as e:
         sys.exit(f"Error: {e}")


### PR DESCRIPTION
```
% onnx2nnoir -o super_resolution.nnoir --graph_name torch_jit_export super_resolution.onnx
Error: This ONNX model includes dimension variables.
{'batch_size'}
Set the values with the `--fix_dimension` option.
% onnx2nnoir -o super_resolution.nnoir --graph_name torch_jit_export --fix_dimension batch_size=1 super_resolution.onnx
2020-11-06 13:11:36.945196840 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv1.bias appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 13:11:36.947018295 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv1.weight appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 13:11:36.947125292 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv2.bias appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 13:11:36.947229494 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv2.weight appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 13:11:36.947331462 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv3.bias appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 13:11:36.947433151 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv3.weight appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 13:11:36.947534560 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv4.bias appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
2020-11-06 13:11:36.947637366 [W:onnxruntime:, graph.cc:814 Graph] Initializer conv4.weight appears in graph inputs and will not be treated as constant value/weight. This may fail some of the graph optimizations, like const folding. Move it out of graph inputs if there is no need to override it, by either re-generating the model with latest exporter/converter or with the tool onnxruntime/tools/python/remove_initializer_from_input.py.
```

I've left `freeze_onnx` for compatibility.