### PR TITLE
twine requires url to upload pypitest package index

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,8 @@ commands:
             pip3 install twine
             export TWINE_USERNAME=__token__
             export TWINE_PASSWORD=$PYPI_API_TOKEN
-            python -m twine upload --non-interactive --repository pypitest dist/*
-            python -m twine upload --non-interactive --repository pypi     dist/*
+            python -m twine upload --non-interactive --repository-url https://test.pypi.org/legacy/ dist/*
+            python -m twine upload --non-interactive --repository     pypi                          dist/*
 
 jobs:
 


### PR DESCRIPTION
fix [this](https://app.circleci.com/pipelines/github/Idein/nnoir/311/workflows/05dc97a5-f45c-44c9-b88e-f84c28cf7a6c/jobs/363)
```
InvalidConfiguration: Missing 'pypitest' section from the configuration file
or not a complete URL in --repository-url.
Maybe you have an out-dated '~/.pypirc' format?
more info: https://packaging.python.org/specifications/pypirc/
```