### PR TITLE
fix bug when the second input of `Div` is 0-dimensional ndarray

### DIFF
--- a/nnoir-onnx/nnoir_onnx/operators/div.py
+++ b/nnoir-onnx/nnoir_onnx/operators/div.py
@@ -1,3 +1,4 @@
+import numpy as np
 from nnoir.functions import *
 
 from .utils import *
@@ -21,7 +22,17 @@ class OpDiv(Op):
         if a in constants and b not in constants:
             raise UnsupportedONNXOperation(self.node, "unimplemented yet")
         elif a not in constants and b in constants:
-            return scale(a, 1 / constants[b])
+            c = constants[b]
+            if type(c) == np.ndarray and c.shape != ():  # usual ndarray
+                w = 1 / c
+            elif type(c) == np.ndarray and c.shape == ():  # ndarray with 0-dimension
+                w = 1 / np.array([float(c)], dtype=np.float32)
+            else:
+                raise UnsupportedONNXOperation(self.node, "bug! (unreachable here)")
+
+            assert type(w) == np.ndarray and w.shape != ()
+            return scale(a, w)
+
         elif a not in constants and b not in constants:
             return [Div(list(self.node.input), list(self.node.output))]
         else:


### PR DESCRIPTION
My PR #111 is implmete for 0-dimensional ndarray.
This PR fix that.