### PR TITLE
Fix bug of Pad

### DIFF
--- a/nnoir-onnx/nnoir_onnx/operators/pad.py
+++ b/nnoir-onnx/nnoir_onnx/operators/pad.py
@@ -24,7 +24,14 @@ class OpPad(Op):
                 if not self.node.input[2] in constants:
                     raise UnsupportedONNXOperation(self.node, 'constant_value must be "constant"')
 
-                self.value = constants[self.node.input[2]]  # constant_value
+                v = constants[self.node.input[2]]  # constant_value
+                if type(v) == np.ndarray:
+                    try:
+                        self.value = float(v.item())
+                    except ValueError:
+                        raise UnsupportedONNXOperation(self.node, "constant_value must be scalar")
+                else:
+                    self.value = float(v)
 
             for attr in self.node.attribute:
                 if attr.name == "mode":

--- a/nnoir-onnx/test/test_pad.py
+++ b/nnoir-onnx/test/test_pad.py
@@ -63,3 +63,30 @@ def test_pad_01():
 
     outputs = ["v1"]
     PadTester({"v0": v0}, outputs).run()
+
+
+def test_pad_02():
+    """
+    opset version >= 11 and 0-dimension ndarray value
+    """
+
+    class PadTester(Base):
+        def __init__(self, inputs, outputs):
+            super().__init__(inputs, outputs)
+
+        def create_onnx(self) -> onnx.ModelProto:
+            node = make_node("Pad", inputs=["v0", "pads", "value"], outputs=["v1"], mode="constant")
+            inputs = [info("v0", TensorProto.FLOAT, (1, 3, 4, 5))]
+            outputs = [info("v1", TensorProto.FLOAT, (1, 5, 6, 7))]
+
+            init_pad = from_array(np.array([0, 1, 1, 1, 0, 1, 1, 1]).astype(np.int64), "pads")
+            pad_value = from_array(np.array(1.0).astype(np.float32), "value")
+
+            graph = make_graph([node], "add_graph", inputs, outputs, initializer=[init_pad, pad_value])
+            model = make_model(graph)
+            return model
+
+    v0 = np.random.rand(1, 3, 4, 5).astype(np.float32)
+
+    outputs = ["v1"]
+    PadTester({"v0": v0}, outputs).run()


### PR DESCRIPTION
The value of Pad in nnoir must be scalar.
Fix 0-dimension ndarray to scalar in onnx2nnoir.