### PR TITLE
nnoir: explicitly collect unreachable resources

### DIFF
--- a/nnoir/nnoir/nnoir.py
+++ b/nnoir/nnoir/nnoir.py
@@ -131,4 +131,7 @@ class NNOIR:
                     break
             return env[n]
 
-        return [eval(o) for o in self.outputs]
+        result = [eval(o) for o in self.outputs]
+        del cast
+        del eval
+        return result


### PR DESCRIPTION
to reduce memory usage.