### PR TITLE
expand release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,36 +68,8 @@ commands:
             echo "Package version: $VERSION"
             test "$VERSION" = "$TAG"
 
-  publish:
-    parameters:
-      dir:
-        type: string
-      token:
-        type: string
-    steps:
-      - run:
-          name: Publish << parameters.dir >>
-          working_directory: << parameters.dir >>
-          environment:
-            PYPI_TOKEN: << parameters.token >>
-          command: |
-            poetry publish --build --username "__token__" --password "$PYPI_TOKEN" --no-interaction
-
-
-  publish-nnoir:
-    parameters:
-      dir:
-        type: string
-    steps:
-      - run:
-          name: Publish << parameters.dir >>
-          working_directory: << parameters.dir >>
-          command: |
-            poetry publish --build --username "__token__" --password "$PYPI_API_TOKEN_NNOIR" --no-interaction
-
 
 jobs:
-
   check-nnoir:
     <<: *defaults
     steps:
@@ -166,26 +138,6 @@ jobs:
             poetry run make -C examples/models -j2
             poetry run make -C test -j2
 
-  release:
-    <<: *defaults
-    parameters:
-      dir:
-        type: string
-      package-name:
-        type: string
-      token:
-        type: string
-    steps:
-      - checkout
-      - poetry-install:
-          dir: << parameters.dir >>
-      - validate-version-with-tag:
-          dir: << parameters.dir >>
-          package-name: << parameters.package-name >>
-      - publish:
-          dir: << parameters.dir >>
-          token: << parameters.token >>
-
   release-nnoir:
     <<: *defaults
     parameters:
@@ -200,8 +152,75 @@ jobs:
       - validate-version-with-tag:
           dir: << parameters.dir >>
           package-name: << parameters.package-name >>
-      - publish-nnoir:
+      - run:
+          name: Publish << parameters.dir >>
+          working_directory: << parameters.dir >>
+          command: |
+            poetry publish --build --username "__token__" --password "$PYPI_API_TOKEN_NNOIR" --no-interaction
+
+
+  release-nnoir-onnx:
+    <<: *defaults
+    parameters:
+      dir:
+        type: string
+      package-name:
+        type: string
+    steps:
+      - checkout
+      - poetry-install:
           dir: << parameters.dir >>
+      - validate-version-with-tag:
+          dir: << parameters.dir >>
+          package-name: << parameters.package-name >>
+      - run:
+          name: Publish << parameters.dir >>
+          working_directory: << parameters.dir >>
+          command: |
+            poetry publish --build --username "__token__" --password "$PYPI_API_TOKEN_NNOIR_ONNX" --no-interaction
+
+
+  release-nnoir-chainer:
+    <<: *defaults
+    parameters:
+      dir:
+        type: string
+      package-name:
+        type: string
+    steps:
+      - checkout
+      - poetry-install:
+          dir: << parameters.dir >>
+      - validate-version-with-tag:
+          dir: << parameters.dir >>
+          package-name: << parameters.package-name >>
+      - run:
+          name: Publish << parameters.dir >>
+          working_directory: << parameters.dir >>
+          command: |
+            poetry publish --build --username "__token__" --password "$PYPI_API_TOKEN_NNOIR_CHAINER" --no-interaction
+
+
+  release-blackonnx:
+    <<: *defaults
+    parameters:
+      dir:
+        type: string
+      package-name:
+        type: string
+    steps:
+      - checkout
+      - poetry-install:
+          dir: << parameters.dir >>
+      - validate-version-with-tag:
+          dir: << parameters.dir >>
+          package-name: << parameters.package-name >>
+      - run:
+          name: Publish << parameters.dir >>
+          working_directory: << parameters.dir >>
+          command: |
+            poetry publish --build --username "__token__" --password "$PYPI_API_TOKEN_BLACKONNX" --no-interaction
+
 
 
 workflows:
@@ -247,7 +266,7 @@ workflows:
 
   release-nnoir-onnx:
     jobs:
-      - release:
+      - release-nnoir-onnx:
           context:
             - docker-hub-creds
           filters:
@@ -257,11 +276,10 @@ workflows:
               ignore: /.*/
           dir: nnoir-onnx
           package-name: nnoir-onnx
-          token: $PYPI_API_TOKEN_NNOIR_ONNX
 
   release-nnoir-chainer:
     jobs:
-      - release:
+      - release-nnoir-chainer:
           context:
             - docker-hub-creds
           filters:
@@ -271,11 +289,10 @@ workflows:
               ignore: /.*/
           dir: nnoir-chainer
           package-name: nnoir-chainer
-          token: $PYPI_API_TOKEN_NNOIR_CHAINER
 
   release-blackonnx:
     jobs:
-      - release:
+      - release-blackonnx:
           context:
             - docker-hub-creds
           filters:
@@ -285,4 +302,3 @@ workflows:
               ignore: /.*/
           dir: blackonnx
           package-name: blackonnx
-          token: $PYPI_API_TOKEN_BLACKONNX


### PR DESCRIPTION
Directly use pypi tokens when  `poetry publish` to workaround the following token error. 
```
#!/bin/bash -eo pipefail
poetry publish --build --username "__token__" --password "$PYPI_TOKEN" --no-interaction

Building nnoir (1.0.9)
  - Building sdist
  - Built nnoir-1.0.9.tar.gz
  - Building wheel
  - Built nnoir-1.0.9-py3-none-any.whl

Publishing nnoir (1.0.9) to PyPI
 - Uploading nnoir-1.0.9-py3-none-any.whl 0% - Uploading nnoir-1.0.9-py3-none-any.whl 100% - Uploading nnoir-1.0.9-py3-none-any.whl 100%

  UploadError

  HTTP Error 403: Invalid or non-existent authentication information. See https://pypi.org/help/#invalid-auth for more information.

  at ~/.local/share/pypoetry/venv/lib/python3.9/site-packages/poetry/publishing/uploader.py:216 in _upload
      212│                     self._register(session, url)
      213│                 except HTTPError as e:
      214│                     raise UploadError(e)
      215│ 
    → 216│             raise UploadError(e)
      217│ 
      218│     def _do_upload(
      219│         self, session, url, dry_run=False
      220│     ):  # type: (requests.Session, str, Optional[bool]) -> None

Exited with code exit status 1
```

https://app.circleci.com/pipelines/github/Idein/nnoir/962/workflows/323fe19e-3969-4ae9-8057-4522b9a8ffcb/jobs/2028