### PR TITLE
`nnoir-metadata`: script for read/write nnoir metadata

### DIFF
--- a/nnoir/README.md
+++ b/nnoir/README.md
@@ -31,15 +31,21 @@ add_nnoir = nnoir.load('add.nnoir')
 ### Read/Write metadata from command line
 
 ```bash
-$ nnoir-metadata mobilenet_v2.nnoir
-name = MobileNet_v2
+$ nnoir-metadata resnet_50.nnoir
+name = CaffeFunction
 description =
 generator.name = chainer
 generator.version = 7.7.0
-$ nnoir-metadata mobilenet_v2.nnoir description "This is Mobilet V2 (description added by nnoir-metadata)"
-$ nnoir-metadata mobilenet_v2.nnoir
-name = MobileNet_v2
-description = This is Mobilet V2 (description added by nnoir-metadata)
+$ nnoir-metadata resnet_50.nnoir --write-description "This is resnet_50 (written by nnoir-metada)"
+$ nnoir-metadata resnet_50.nnoir                                            
+name = CaffeFunction
+description = This is resnet_50 (written by nnoir-metada)
+generator.name = chainer
+generator.version = 7.7.0
+$ nnoir-metadata resnet_50.nnoir --write-name "CaffeFunction_V2"
+$ nnoir-metadata resnet_50.nnoir
+name = CaffeFunction_V2
+description = This is resnet_50 (written by nnoir-metada)
 generator.name = chainer
 generator.version = 7.7.0
 ```

--- a/nnoir/README.md
+++ b/nnoir/README.md
@@ -10,7 +10,7 @@ pip install nnoir
 
 ### Create & Save
 
-```
+```python
 inputs  = [nnoir.Value(b'v0', dtype='<f4', shape=(10,10)),
            nnoir.Value(b'v1', dtype='<f4', shape=(10,10))]
 outputs = [nnoir.Value(b'v2', dtype='<f4', shape=(10,10))]
@@ -24,6 +24,22 @@ result.dump('add.nnoir')
 
 ### Load
 
-```
+```python
 add_nnoir = nnoir.load('add.nnoir')
+```
+
+### Read/Write metadata from command line
+
+```bash
+$ nnoir-metadata mobilenet_v2.nnoir
+name = MobileNet_v2
+description =
+generator.name = chainer
+generator.version = 7.7.0
+$ nnoir-metadata mobilenet_v2.nnoir description "This is Mobilet V2 (description added by nnoir-metadata)"
+$ nnoir-metadata mobilenet_v2.nnoir
+name = MobileNet_v2
+description = This is Mobilet V2 (description added by nnoir-metadata)
+generator.name = chainer
+generator.version = 7.7.0
 ```

--- a/nnoir/nnoir/load.py
+++ b/nnoir/nnoir/load.py
@@ -13,12 +13,15 @@ def load(nnoir_file):
         nnoir = msgpack.unpackb(f.read(), raw=True)
     name = nnoir[b"nnoir"][b"model"][b"name"]
     generator_name = nnoir[b"nnoir"][b"model"][b"generator"][b"name"]
+    description = b""
+    if b"description" in nnoir[b"nnoir"][b"model"]:
+        description = nnoir[b"nnoir"][b"model"][b"description"]
     generator_version = nnoir[b"nnoir"][b"model"][b"generator"][b"version"]
     inputs = nnoir[b"nnoir"][b"model"][b"inputs"]
     outputs = nnoir[b"nnoir"][b"model"][b"outputs"]
     vs = [_decode_value(v) for v in nnoir[b"nnoir"][b"model"][b"values"]]
     fs = [_decode_function(f) for f in nnoir[b"nnoir"][b"model"][b"functions"]]
-    return NNOIR(name, generator_name, generator_version, inputs, outputs, vs, fs)
+    return NNOIR(name, generator_name, generator_version, inputs, outputs, vs, fs, description)
 
 
 def _decode_function(function):

--- a/nnoir/nnoir/metadata.py
+++ b/nnoir/nnoir/metadata.py
@@ -1,0 +1,97 @@
+import argparse
+from typing import Optional
+
+import msgpack
+
+
+def read_name(nnoir) -> str:
+    return nnoir[b"nnoir"][b"model"][b"name"].decode("ascii")
+
+
+def read_description(nnoir) -> str:
+    description = ""
+    if b"description" in nnoir[b"nnoir"][b"model"]:
+        description = nnoir[b"nnoir"][b"model"][b"description"].decode("ascii")
+
+    return description
+
+
+def read_generator_name(nnoir) -> str:
+    return nnoir[b"nnoir"][b"model"][b"generator"][b"name"].decode("ascii")
+
+
+def read_generator_version(nnoir) -> str:
+    return nnoir[b"nnoir"][b"model"][b"generator"][b"version"].decode("ascii")
+
+
+def write_name(nnoir, name: str):
+    name = nnoir[b"nnoir"][b"model"][b"name"] = name.encode(encoding="utf-8")
+
+
+def write_description(nnoir, description: str) -> str:
+    nnoir[b"nnoir"][b"model"][b"description"] = description.encode(encoding="utf-8")
+
+
+def write_generator_name(nnoir, generator_name) -> str:
+    generator_name = nnoir[b"nnoir"][b"model"][b"generator"][b"name"] = generator_name.encode(encoding="utf-8")
+
+
+def write_generator_version(nnoir, generator_version):
+    generator_version = nnoir[b"nnoir"][b"model"][b"generator"][b"version"] = generator_version.encode(encoding="utf-8")
+
+
+def print_metadata(nnoir):
+    print(f"name = {read_name(nnoir)}")
+    print(f"description = {read_description(nnoir)}")
+    print(f"generator.name = {read_generator_name(nnoir)}")
+    print(f"generator.version = {read_generator_version(nnoir)}")
+
+
+def read_metadata(nnoir, key: str) -> str:
+    if key == "name":
+        return read_name(nnoir)
+    elif key == "description":
+        return read_description(nnoir)
+    elif key == "generator.name":
+        return read_generator_name(nnoir)
+    elif key == "generator.version":
+        return read_generator_version(nnoir)
+    else:
+        raise RuntimeError(f"invalid key for metadat: {key}")
+
+
+def write_metadata(nnoir, key: str, value: str):
+    if key == "name":
+        write_name(nnoir, value)
+    elif key == "description":
+        write_description(nnoir, value)
+    elif key == "generator.name":
+        write_generator_name(nnoir, value)
+    elif key == "generator.version":
+        write_generator_version(nnoir, value)
+
+
+def main(file_name: str, key: Optional[str], value: Optional[str]):
+    with open(file_name, "rb") as f:
+        nnoir = msgpack.unpackb(f.read(), raw=True)
+
+        if key is None:
+            return print_metadata(nnoir)
+
+        if value is None:
+            return print(read_metadata(nnoir, key))
+
+        write_metadata(nnoir, key, value)
+
+    with open(file_name, "wb") as f:
+        f.write(msgpack.packb(nnoir, use_bin_type=False))
+
+
+def nnoir_metadata():
+    parser = argparse.ArgumentParser(description="edit NNOIR meta data")
+    parser.add_argument(dest="input", type=str, metavar="NNOIR", help="input(NNOIR) file path")
+    parser.add_argument(dest="key", type=str, nargs="?", metavar="<key>", help="meta data key")
+    parser.add_argument(dest="value", type=str, nargs="?", metavar="<value>", help="meta data value")
+    args = parser.parse_args()
+
+    main(args.input, args.key, args.value)

--- a/nnoir/nnoir/metadata.py
+++ b/nnoir/nnoir/metadata.py
@@ -1,27 +1,26 @@
 import argparse
-from typing import Optional
 
 import msgpack
 
 
 def read_name(nnoir) -> str:
-    return nnoir[b"nnoir"][b"model"][b"name"].decode("ascii")
+    return nnoir[b"nnoir"][b"model"][b"name"].decode("utf-8")
 
 
 def read_description(nnoir) -> str:
     description = ""
     if b"description" in nnoir[b"nnoir"][b"model"]:
-        description = nnoir[b"nnoir"][b"model"][b"description"].decode("ascii")
+        description = nnoir[b"nnoir"][b"model"][b"description"].decode("utf-8")
 
     return description
 
 
 def read_generator_name(nnoir) -> str:
-    return nnoir[b"nnoir"][b"model"][b"generator"][b"name"].decode("ascii")
+    return nnoir[b"nnoir"][b"model"][b"generator"][b"name"].decode("utf-8")
 
 
 def read_generator_version(nnoir) -> str:
-    return nnoir[b"nnoir"][b"model"][b"generator"][b"version"].decode("ascii")
+    return nnoir[b"nnoir"][b"model"][b"generator"][b"version"].decode("utf-8")
 
 
 def write_name(nnoir, name: str):
@@ -32,14 +31,6 @@ def write_description(nnoir, description: str) -> str:
     nnoir[b"nnoir"][b"model"][b"description"] = description.encode(encoding="utf-8")
 
 
-def write_generator_name(nnoir, generator_name) -> str:
-    generator_name = nnoir[b"nnoir"][b"model"][b"generator"][b"name"] = generator_name.encode(encoding="utf-8")
-
-
-def write_generator_version(nnoir, generator_version):
-    generator_version = nnoir[b"nnoir"][b"model"][b"generator"][b"version"] = generator_version.encode(encoding="utf-8")
-
-
 def print_metadata(nnoir):
     print(f"name = {read_name(nnoir)}")
     print(f"description = {read_description(nnoir)}")
@@ -47,51 +38,25 @@ def print_metadata(nnoir):
     print(f"generator.version = {read_generator_version(nnoir)}")
 
 
-def read_metadata(nnoir, key: str) -> str:
-    if key == "name":
-        return read_name(nnoir)
-    elif key == "description":
-        return read_description(nnoir)
-    elif key == "generator.name":
-        return read_generator_name(nnoir)
-    elif key == "generator.version":
-        return read_generator_version(nnoir)
-    else:
-        raise RuntimeError(f"invalid key for metadat: {key}")
-
-
-def write_metadata(nnoir, key: str, value: str):
-    if key == "name":
-        write_name(nnoir, value)
-    elif key == "description":
-        write_description(nnoir, value)
-    elif key == "generator.name":
-        write_generator_name(nnoir, value)
-    elif key == "generator.version":
-        write_generator_version(nnoir, value)
-
-
-def main(file_name: str, key: Optional[str], value: Optional[str]):
-    with open(file_name, "rb") as f:
-        nnoir = msgpack.unpackb(f.read(), raw=True)
-
-        if key is None:
-            return print_metadata(nnoir)
-
-        if value is None:
-            return print(read_metadata(nnoir, key))
-
-        write_metadata(nnoir, key, value)
-
-    with open(file_name, "wb") as f:
-        f.write(msgpack.packb(nnoir, use_bin_type=False))
-
-
 def nnoir_metadata():
     parser = argparse.ArgumentParser(description="read/write NNOIR meta data")
     parser.add_argument(dest="input", type=str, metavar="NNOIR", help="input(NNOIR) file path")
-    parser.add_argument(dest="key", type=str, nargs="?", metavar="<key>", help="meta data key")
-    parser.add_argument(dest="value", type=str, nargs="?", metavar="<value>", help="meta data value")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--write-description", type=str, dest="new_description", metavar="<new description>", help="overwrite description"
+    )
+    parser.add_argument("--write-name", type=str, dest="new_name", metavar="<new name>", help="overwrite name")
 
-    main(args.input, args.key, args.value)
+    args = parser.parse_args()
+    with open(args.input, "rb") as f:
+        nnoir = msgpack.unpackb(f.read(), raw=True)
+
+    if args.new_description is None and args.new_name is None:
+        return print_metadata(nnoir)
+
+    if args.new_description:
+        write_description(nnoir, args.new_description)
+    if args.new_name:
+        write_name(nnoir, args.new_name)
+
+    with open(args.input, "wb") as f:
+        f.write(msgpack.packb(nnoir, use_bin_type=False))

--- a/nnoir/nnoir/metadata.py
+++ b/nnoir/nnoir/metadata.py
@@ -88,7 +88,7 @@ def main(file_name: str, key: Optional[str], value: Optional[str]):
 
 
 def nnoir_metadata():
-    parser = argparse.ArgumentParser(description="edit NNOIR meta data")
+    parser = argparse.ArgumentParser(description="read/write NNOIR meta data")
     parser.add_argument(dest="input", type=str, metavar="NNOIR", help="input(NNOIR) file path")
     parser.add_argument(dest="key", type=str, nargs="?", metavar="<key>", help="meta data key")
     parser.add_argument(dest="value", type=str, nargs="?", metavar="<value>", help="meta data value")

--- a/nnoir/nnoir/metadata.py
+++ b/nnoir/nnoir/metadata.py
@@ -1,34 +1,30 @@
 import argparse
 
-import msgpack
+from .load import load
 
 
 def read_name(nnoir) -> str:
-    return nnoir[b"nnoir"][b"model"][b"name"].decode("utf-8")
+    return nnoir.name.decode("utf-8")
 
 
 def read_description(nnoir) -> str:
-    description = ""
-    if b"description" in nnoir[b"nnoir"][b"model"]:
-        description = nnoir[b"nnoir"][b"model"][b"description"].decode("utf-8")
-
-    return description
+    return nnoir.description.decode("utf-8")
 
 
 def read_generator_name(nnoir) -> str:
-    return nnoir[b"nnoir"][b"model"][b"generator"][b"name"].decode("utf-8")
+    return nnoir.generator_name.decode("utf-8")
 
 
 def read_generator_version(nnoir) -> str:
-    return nnoir[b"nnoir"][b"model"][b"generator"][b"version"].decode("utf-8")
+    return nnoir.generator_version.decode("utf-8")
 
 
 def write_name(nnoir, name: str):
-    name = nnoir[b"nnoir"][b"model"][b"name"] = name.encode(encoding="utf-8")
+    nnoir.name = name.encode(encoding="utf-8")
 
 
 def write_description(nnoir, description: str) -> str:
-    nnoir[b"nnoir"][b"model"][b"description"] = description.encode(encoding="utf-8")
+    nnoir.description = description.encode(encoding="utf-8")
 
 
 def print_metadata(nnoir):
@@ -47,16 +43,14 @@ def nnoir_metadata():
     parser.add_argument("--write-name", type=str, dest="new_name", metavar="<new name>", help="overwrite name")
 
     args = parser.parse_args()
-    with open(args.input, "rb") as f:
-        nnoir = msgpack.unpackb(f.read(), raw=True)
+    nnoir = load(args.input)
 
     if args.new_description is None and args.new_name is None:
         return print_metadata(nnoir)
 
-    if args.new_description:
+    if args.new_description is not None:
         write_description(nnoir, args.new_description)
-    if args.new_name:
+    if args.new_name is not None:
         write_name(nnoir, args.new_name)
 
-    with open(args.input, "wb") as f:
-        f.write(msgpack.packb(nnoir, use_bin_type=False))
+    nnoir.dump(args.input)

--- a/nnoir/nnoir/nnoir.py
+++ b/nnoir/nnoir/nnoir.py
@@ -9,7 +9,7 @@ class InvalidNNOIRData(Exception):
 
 
 class NNOIR:
-    def __init__(self, name, generator_name, generator_version, inputs, outputs, values, functions, description=""):
+    def __init__(self, name, generator_name, generator_version, inputs, outputs, values, functions, description=b""):
         cident = re.compile(rb"^[_A-Za-z][_0-9A-Za-z]*$")
         c_keywords = [
             "auto",

--- a/nnoir/nnoir/nnoir.py
+++ b/nnoir/nnoir/nnoir.py
@@ -9,16 +9,7 @@ class InvalidNNOIRData(Exception):
 
 
 class NNOIR:
-    def __init__(
-        self,
-        name,
-        generator_name,
-        generator_version,
-        inputs,
-        outputs,
-        values,
-        functions,
-    ):
+    def __init__(self, name, generator_name, generator_version, inputs, outputs, values, functions, description=""):
         cident = re.compile(rb"^[_A-Za-z][_0-9A-Za-z]*$")
         c_keywords = [
             "auto",
@@ -69,6 +60,7 @@ class NNOIR:
         if not cident.match(name) or name.decode() in c_keywords:
             raise InvalidNNOIRData('graph name "{}" MUST be C identifier.'.format(name))
         self.name = name
+        self.description = description
         self.generator_name = generator_name
         self.generator_version = generator_version
         self.inputs = inputs
@@ -83,6 +75,7 @@ class NNOIR:
     def to_model(self):
         return {
             b"name": self.name,
+            b"description": self.description,
             b"generator": {
                 b"name": self.generator_name,
                 b"version": self.generator_version,

--- a/nnoir/pyproject.toml
+++ b/nnoir/pyproject.toml
@@ -32,6 +32,7 @@ pytest = "^6.2.5"
 [tool.poetry.scripts]
 nnoir2dot = "nnoir.dot:nnoir2dot"
 nnrunner = "nnoir.runner:main"
+nnoir-metadata = "nnoir.metadata:nnoir_metadata"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
```bash
$ nnoir-metadata resnet_50.nnoir
name = CaffeFunction
description =
generator.name = chainer
generator.version = 7.7.0
$ nnoir-metadata resnet_50.nnoir --write-description "This is resnet_50 (written by nnoir-metada)"
$ nnoir-metadata resnet_50.nnoir                                            
name = CaffeFunction
description = This is resnet_50 (written by nnoir-metada)
generator.name = chainer
generator.version = 7.7.0
$ nnoir-metadata resnet_50.nnoir --write-name "CaffeFunction_V2"
$ nnoir-metadata resnet_50.nnoir
name = CaffeFunction_V2
description = This is resnet_50 (written by nnoir-metada)
generator.name = chainer
generator.version = 7.7.0
```