### PR TITLE
fix _list_constant_nodes()

### DIFF
--- a/nnoir-onnx/nnoir_onnx/onnx.py
+++ b/nnoir-onnx/nnoir_onnx/onnx.py
@@ -347,18 +347,17 @@ Set the values with the `--fix_dimension` option."""
                     generator = self._find_generator(n)
                     if generator.op_type == "Shape":  # In nnoir, array shape is known information.
                         result.append(n)
-                    else:
-                        next_nodes = []
-                        if hasattr(generator, "input"):
-                            next_nodes = [i for i in generator.input if i not in visited and len(i) > 0]
-                        dfs(visited, next_nodes, result)
-                        if hasattr(generator, "input"):
-                            if all([i in result for i in generator.input]):
-                                for o in generator.output:
-                                    result.append(o)
-                        else:
+                    next_nodes = []
+                    if hasattr(generator, "input"):
+                        next_nodes = [i for i in generator.input if i not in visited and len(i) > 0]
+                    dfs(visited, next_nodes, result)
+                    if hasattr(generator, "input"):
+                        if all([i in result for i in generator.input]):
                             for o in generator.output:
                                 result.append(o)
+                    else:
+                        for o in generator.output:
+                            result.append(o)
                 visited.append(n)
 
         result = []


### PR DESCRIPTION
Fixed to check if nodes before the `Shape` node have constant.

![image](https://github.com/Idein/nnoir/assets/5870257/0ba77f6e-489d-47af-9010-a2617a0b11d9)
