### PR TITLE
Add opset version check for slice

### DIFF
--- a/nnoir-onnx/README.md
+++ b/nnoir-onnx/README.md
@@ -92,6 +92,7 @@ docker run --rm -it -u $UID:$GID -v $(pwd):/work idein/nnoir-tools:20240208 onnx
 * [Sigmoid](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Sigmoid)
 * [Sin](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Sin)
 * [Slice](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Slice)
+    * must be from opset version >= 10
     * `starts` must be [Constant](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Constant) value or have initializer value
     * `ends` must be [Constant](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Constant) value or have initializer value
     * `axes` must be [Constant](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Constant) value or have initializer value

--- a/nnoir-onnx/nnoir_onnx/operators/slice.py
+++ b/nnoir-onnx/nnoir_onnx/operators/slice.py
@@ -12,6 +12,9 @@ class OpSlice(Op):
     def __init__(self, node: onnx.NodeProto, *args: Any):
         super(OpSlice, self).__init__(node, *args)
 
+        if self.opset_version < 10:
+            raise UnsupportedONNXOperation(self.node, "only opset_version >= 10 is supported")
+
     def to_function(self, env: Dict[str, NDArray[Any]], constants: Dict[str, NDArray[Any]]) -> List[Function]:
         axes_key = None
         steps_key = None


### PR DESCRIPTION
sliceの実装がopset10以降を想定したものであったため、opset9以前の場合は`UnsupportedONNXOperation`を返すようにした