### PR TITLE
Remove usage of pkg_resources from CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
           working_directory: << parameters.dir >>
           command: |
             TAG=$(echo ${CIRCLE_TAG} |sed -e 's/<< parameters.package-name >>-//')
-            VERSION=$(poetry run python -c 'import pkg_resources; print(pkg_resources.get_distribution("<< parameters.package-name >>").version)')
+            VERSION=$(poetry run python -c 'import importlib.metadata; print(importlib.metadata.version("<< parameters.package-name >>"))')
             echo "Git tag: $TAG"
             echo "Package version: $VERSION"
             test "$VERSION" = "$TAG"


### PR DESCRIPTION
- Poetry のv2系でsetuptoolsがdefaultの依存から削除されてしまったため、リリース時のCIでエラーが出るようになっていました。そこで、setup_toolsに依存したいた部分を別のライブラリを使用するように書き換えました。
- ローカルで動くことを確認済みです。